### PR TITLE
Bug fix: log error and sink when parseError handler is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,12 +358,13 @@ AMQPStream.prototype._handleIncomingMessage = function(message, headers, deliver
   };
 
   if(isJSON && deliveryInfo.parseError) {
+    this.sink.write(RejectMessage(serializableMessage));
     if(this.source.listeners('parseError').length) {
       return this.source.emit("parseError", deliveryInfo.parseError, deliveryInfo.rawData);
     } else {
-      this.__debug("Automatically rejecting malformed message. " +
+      console.error("Automatically rejecting malformed message. " +
                   "Add listener to 'parseError' for custom behavior");
-      return this.sink.write(RejectMessage(serializableMessage));
+      return;
     }
   }
   this.__debug("Received message. Inserted ack into index " + serializableMessage._meta.ackIndex);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-queue-stream",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Reliable streaming interface to rabbitmq queues",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -605,7 +605,12 @@ describe("rabbitmq-queue-stream", function() {
         });
 
         it("emits a `parseError` event on invalid JSON when there are event listeners", function (done) {
+          var rejected = [];
+          instance.sink.on("rejected", function(msg) {
+            rejected.push(msg);
+          });
           instance.source.on("parseError", function(msg) {
+            expect(rejected.length).to.be.equal(1);
             done();
           });
           instance._handleIncomingMessage(null, {}, deliveryInfo, amqpResponseStub);


### PR DESCRIPTION
If the client does not define a parseError handler (which is ok if
they are not using JSON for example) - then broken JSON parse flows
silently and only logs to __debug (which is mostly off in usual usage
and therefore never logged) and silently sinks the message.

Therefore, the client doesn't know if such an error was triggered
because handling parseError isn't forced (to maintain flexibility
where client wants to handle raw messages directly).

This change forces the message to be sinked and then emits a parseError
event. If not handler is defined, it will log an error so that the user
can deal with it.
